### PR TITLE
Changing file path for phpmyadmin configuration file within VM

### DIFF
--- a/puppet/modules/joindin/manifests/web/phpmyadmin.pp
+++ b/puppet/modules/joindin/manifests/web/phpmyadmin.pp
@@ -6,7 +6,7 @@ class joindin::web::phpmyadmin {
     }
 
     # Setup our own phpmyadmin configuration file
-    file { "/etc/phpmyadmin/apache.conf" :
+    file { "/etc/apache2/conf.d/phpmyadmin.conf" :
         source  => "puppet:///modules/joindin/phpmyadmin.conf",
         owner   => "root",
         group   => "root",


### PR DESCRIPTION
Exceptions thrown during provisioning of test applications under VM. To reproduce, follow Joindin-vm README setup through to step 3 of "Running the Tests" section. `vagrant provision` command should fail.

Terminal output on execution of vagrant provision:
https://gist.github.com/AndyJS/77bd87fdc84132c37a29

Issue appears to be down to puppet attempting to provision phpmyadmin configuration file for apache in an invalid location. Path seems to imply provisioning was intended for Red Hat, yet the box is based on Debian.

Provisioning output and phpmyadmin.pp script specify httpd directory, which does not exist:
https://gist.github.com/AndyJS/d2abaf382b1323f04867

Apache configurations look to be stored under /etc/apache2/conf.d, as expected under Debian:
https://gist.github.com/AndyJS/bffa6981ff2660870fbd

Once change was committed, a re-run of vagrant provision resulted in error-free output:
https://gist.github.com/AndyJS/a0f03173de24062cfc6a
