### PR TITLE
Fixed references to non-existant /usr/share/phpMyAdmin path

### DIFF
--- a/puppet/modules/joindin/files/phpmyadmin.conf
+++ b/puppet/modules/joindin/files/phpmyadmin.conf
@@ -7,25 +7,25 @@
 # But allowing phpMyAdmin to anyone other than localhost should be considered
 # dangerous unless properly secured by SSL
 
-Alias /phpMyAdmin /usr/share/phpMyAdmin
-Alias /phpmyadmin /usr/share/phpMyAdmin
+Alias /phpMyAdmin /usr/share/phpmyadmin
+Alias /phpmyadmin /usr/share/phpmyadmin
 
 # These directories do not require access over HTTP - taken from the original
 # phpMyAdmin upstream tarball
 #
-<Directory /usr/share/phpMyAdmin/libraries/>
+<Directory /usr/share/phpmyadmin/libraries/>
     Order Deny,Allow
     Deny from All
     Allow from None
 </Directory>
 
-<Directory /usr/share/phpMyAdmin/setup/lib/>
+<Directory /usr/share/phpmyadmin/setup/lib/>
     Order Deny,Allow
     Deny from All
     Allow from None
 </Directory>
 
-<Directory /usr/share/phpMyAdmin/setup/frames/>
+<Directory /usr/share/phpmyadmin/setup/frames/>
     Order Deny,Allow
     Deny from All
     Allow from None


### PR DESCRIPTION
Testing changes for this PR dependant upon fix made by PR #40, as phpmyadmin.pp needs to provision the configuration file to the correct Apache directory for the URL to be made accessible.

phpMyAdmin should be accessible for testing purposes, served from the VM, after following the "Running the Tests" README section, however visiting http://localhost:8080/phpmyadmin produces 404 response, as attached.

![joindin-2014-10-3-phpmyadmin-404](https://cloud.githubusercontent.com/assets/884138/4501103/211af4d8-4aa3-11e4-87a2-843324e3de5f.png)

The Alias and Directory directives in the provisioned phpMyAdmin configuration file point to an invalid capitalised path which does not exist:
https://gist.github.com/AndyJS/7f79d61aae5b5c847a27

Apache log at the time of request:
https://gist.github.com/AndyJS/405b57e33f02b8c11ff5

Once changes have been made, a reprovisioning followed by an Apache restart results in a locally accessible phpMyAdmin:

![joindin-2014-10-3-phpmyadmin-success](https://cloud.githubusercontent.com/assets/884138/4501119/9e044292-4aa3-11e4-9051-3a9242790156.png)
