### PR TITLE
Store files used to stop puppet initialising the database & config in home

### DIFF
--- a/puppet/modules/joindin/manifests/app.pp
+++ b/puppet/modules/joindin/manifests/app.pp
@@ -37,7 +37,7 @@ class joindin::app (
     # Seed database
     exec { 'seed-db':
         creates => '/home/vagrant/.seeded',
-        command => "mysql $dbname < /tmp/seed.sql && touch /home/vagrant/.seeded",
+        command => "mysql $dbname < /home/vagrant/seed.sql && touch /home/vagrant/.seeded",
         require => [
                        Exec['init-db'],
                        Exec['seed-data'],

--- a/puppet/modules/joindin/manifests/app.pp
+++ b/puppet/modules/joindin/manifests/app.pp
@@ -9,7 +9,7 @@ class joindin::app (
         creates => '/home/vagrant/.patched',
         command => "/vagrant/joindin-api/scripts/patchdb.sh \
                     -t /vagrant/joindin-api -d $dbname -u $dbuser \
-                    -p $dbpass -i && touch /tmp/.patched",
+                    -p $dbpass -i && touch /home/vagrant/.patched",
         require => Exec['create-db'],
     }
 
@@ -27,7 +27,7 @@ class joindin::app (
     # Generate seed data
     exec { 'seed-data':
         creates => '/home/vagrant/seed.sql',
-        command => 'php /vagrant/joindin-api/tools/dbgen/generate.php > /tmp/seed.sql',
+        command => 'php /vagrant/joindin-api/tools/dbgen/generate.php > /home/vagrant/seed.sql',
         require => [
 	    Package['php'],
 	    Exec['init-db'],
@@ -37,7 +37,7 @@ class joindin::app (
     # Seed database
     exec { 'seed-db':
         creates => '/home/vagrant/.seeded',
-        command => "mysql $dbname < /tmp/seed.sql && touch /tmp/.seeded",
+        command => "mysql $dbname < /tmp/seed.sql && touch /home/vagrant/.seeded",
         require => [
                        Exec['init-db'],
                        Exec['seed-data'],
@@ -93,7 +93,7 @@ class joindin::app (
     # Set some configuration for the VM
     exec { 'application-config-values':
         creates => '/home/vagrant/.config_values_set',
-        command => "sh /vagrant/scripts/fixConfig.sh && touch /tmp/.config_values_set",
+        command => "sh /vagrant/scripts/fixConfig.sh && touch /home/vagrant/.config_values_set",
         require => [
             File['application-config'],
             File['web2-config'],

--- a/puppet/modules/joindin/manifests/app.pp
+++ b/puppet/modules/joindin/manifests/app.pp
@@ -6,7 +6,7 @@ class joindin::app (
 
     # Initialize database structure
     exec { 'init-db':
-        creates => '/tmp/.patched',
+        creates => '/home/vagrant/.patched',
         command => "/vagrant/joindin-api/scripts/patchdb.sh \
                     -t /vagrant/joindin-api -d $dbname -u $dbuser \
                     -p $dbpass -i && touch /tmp/.patched",
@@ -26,7 +26,7 @@ class joindin::app (
 
     # Generate seed data
     exec { 'seed-data':
-        creates => '/tmp/seed.sql',
+        creates => '/home/vagrant/seed.sql',
         command => 'php /vagrant/joindin-api/tools/dbgen/generate.php > /tmp/seed.sql',
         require => [
 	    Package['php'],
@@ -36,7 +36,7 @@ class joindin::app (
 
     # Seed database
     exec { 'seed-db':
-        creates => '/tmp/.seeded',
+        creates => '/home/vagrant/.seeded',
         command => "mysql $dbname < /tmp/seed.sql && touch /tmp/.seeded",
         require => [
                        Exec['init-db'],
@@ -92,7 +92,7 @@ class joindin::app (
 
     # Set some configuration for the VM
     exec { 'application-config-values':
-        creates => '/tmp/.config_values_set',
+        creates => '/home/vagrant/.config_values_set',
         command => "sh /vagrant/scripts/fixConfig.sh && touch /tmp/.config_values_set",
         require => [
             File['application-config'],


### PR DESCRIPTION
This ensures that if someone does a vagrant halt and then a vagrant up -- provision, that
they only get new patches and not a re-initialised database.