### PR TITLE
JOINDIN-595 - Fix for VM provision error due to nodejs build

### DIFF
--- a/puppet/modules/joindin/manifests/node.pp
+++ b/puppet/modules/joindin/manifests/node.pp
@@ -1,6 +1,8 @@
 class joindin::node {
 
-    include nodejs
+    class { 'nodejs':
+      make_install => false
+    }
 
     package { 'grunt-cli':
       provider => 'npm',


### PR DESCRIPTION
As seen on JOINDIN-595, on provision, VMs were failing as there was a version of g++ that was too low to support the compilation of nodejs.

This patch calls the nodejs puppet class directly, making sure to specify that we want to use the nodejs pre-built packages rather than building it for ourselves on provision.

Testing seems to show that nodejs 4 appears to install properly this way and is available via terminal for use.