### PR TITLE
Temporarily disable the elastic search install

### DIFF
--- a/puppet/modules/joindin/manifests/init.pp
+++ b/puppet/modules/joindin/manifests/init.pp
@@ -20,5 +20,5 @@ class joindin {
     include joindin::test
     include joindin::mailcatcher
     include joindin::node
-    include joindin::elastic
+    # include joindin::elastic
 }


### PR DESCRIPTION
We have a hackathon this evening and this will cause a bad on boarding experience until we get it into the box on the CDN.