### PR TITLE
Symlink web1's inc to web2

### DIFF
--- a/puppet/modules/joindin/manifests/web.pp
+++ b/puppet/modules/joindin/manifests/web.pp
@@ -106,4 +106,10 @@ class joindin::web ($phpmyadmin = false, $host = 'dev.joind.in', $port = 80) {
         require => [Package['php']],
         notify  => Service['apache']
     }
+
+    # symlink for icons
+    file { "/vagrant/joindin-web2/web/inc":
+      ensure => 'link',
+      target => "/vagrant/joind.in/src/inc",
+    }
 }


### PR DESCRIPTION
This allows event icons to display in web2.