### PR TITLE
Updates due to rename of joind.in to joindin-legacy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ nbproject/
 .idea
 .DS_Store
 .vagrant
-joind.in/
+joindin-legacy/
 joindin-api/
 joindin-web2/
 Guardfile

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ by its terms.
    - Ruby (http://www.ruby-lang.org/)
    - Vagrant (http://vagrantup.com/) version 1.5+
 1. Fork the following joind.in repositories:
-	- [joind.in](https://github.com/joindin/joind.in)
+	- [joindin-legacy](https://github.com/joindin/joindin-legacy)
 	- [joindin-api](https://github.com/joindin/joindin-api)
 	- [joindin-web2](https://github.com/joindin/joindin-web2)
 	- [joindin-vm](https://github.com/joindin/joindin-vm)
@@ -47,19 +47,19 @@ by its terms.
    
        If you are on Linux, run this:
 
-            (echo ; echo "10.223.175.44 dev.joind.in api.dev.joind.in web2.dev.joind.in") | sudo tee -a /etc/hosts
+            (echo ; echo "10.223.175.44 dev.joind.in api.dev.joind.in legacy.dev.joind.in") | sudo tee -a /etc/hosts
        
        If you are on OSX, run this:
 
-            echo "10.223.175.44 dev.joind.in api.dev.joind.in web2.dev.joind.in" | sudo tee -a /etc/hosts
+            echo "10.223.175.44 dev.joind.in api.dev.joind.in legacy.dev.joind.in" | sudo tee -a /etc/hosts
 
        If you are on Windows, run this on the cmd line
 
-            echo 10.223.175.44 dev.joind.in api.dev.joind.in web2.dev.joind.in >> %SYSTEMDRIVE%\Windows\System32\Drivers\Etc\Hosts
+            echo 10.223.175.44 dev.joind.in api.dev.joind.in legacy.dev.joind.in >> %SYSTEMDRIVE%\Windows\System32\Drivers\Etc\Hosts
 
 1. Browse to the sites
 	- For the joind.in site: http://dev.joind.in/
-	- For the responsive site: http://web2.dev.joind.in/
+	- For the legacy site: http://legacy.dev.joind.in/
 	- For the API: http://api.dev.joind.in/
 
 1. You can log to joind.in test site with those credentials for an admin account:
@@ -103,15 +103,15 @@ To install the testing tools in the VM
 1. Wait for the testing tools to be installed. This will take a few minutes.
 1. Run the joind.in tests with this command from inside the VM
 ```
-        cd /vagrant/joind.in && phing
+        cd /vagrant/joindin-web2 && phing
 ```
 1. Run the joindin-api tests with this command from inside the VM
 ```
         cd /vagrant/joindin-api && phing
 ```
-1. Run the joindin-web2 tests with this command from inside the VM
+1. Run the joindin-legacy tests with this command from inside the VM
 ```
-        cd /vagrant/joindin-web2 && phing
+        cd /vagrant/joindin-legacy && phing
 ```
 
 ## Troubleshooting

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure("2") do |config|
 
     ji_config.vm.host_name = "dev.joind.in"
     if Vagrant.has_plugin?('vagrant-hostsupdater')
-      ji_config.hostsupdater.aliases = ["web2.dev.joind.in", "api.dev.joind.in"]
+      ji_config.hostsupdater.aliases = ["legacy.dev.joind.in", "api.dev.joind.in"]
     end
 
     # Forward a port from the guest to the host, which allows for outside

--- a/puppet/manifests/joindin.pp
+++ b/puppet/manifests/joindin.pp
@@ -10,9 +10,9 @@ node default {
 
 notify { 'urls':
     message => 'VM is ready. You can view the application on
-        `http://web2.dev.joind.in/`
-        `http://api.dev.joind.in/`
         `http://dev.joind.in/`
+        `http://api.dev.joind.in/`
+        `http://legacy.dev.joind.in/`
         ',
     require => Class['joindin'],
 }

--- a/puppet/modules/joindin/manifests/app.pp
+++ b/puppet/modules/joindin/manifests/app.pp
@@ -46,7 +46,7 @@ class joindin::app (
 
     # Set database config for application
     file { 'database-config':
-        path   => '/vagrant/joind.in/src/system/application/config/database.php',
+        path   => '/vagrant/joindin-legacy/src/system/application/config/database.php',
         content => template('joindin/database.php.erb'),
 		replace => false, 
     }
@@ -59,8 +59,8 @@ class joindin::app (
 
     # Set core config for application
     file { 'application-config':
-        path    => '/vagrant/joind.in/src/system/application/config/config.php',
-        source  => '/vagrant/joind.in/src/system/application/config/config.php.dist',
+        path    => '/vagrant/joindin-legacy/src/system/application/config/config.php',
+        source  => '/vagrant/joindin-legacy/src/system/application/config/config.php.dist',
         replace => no,
     }
 

--- a/puppet/modules/joindin/manifests/test/test.pp
+++ b/puppet/modules/joindin/manifests/test/test.pp
@@ -92,7 +92,7 @@ class joindin::test::test {
     # Announce test-suite
     notify { 'test':
       message => 'Test-suite ready - run in VM with 
-          `cd /vagrant/joind.in && phing`
+          `cd /vagrant/joindin-legacy && phing`
           `cd /vagrant/joindin-api && phing`
           `cd /vagrant/joindin-web2 && phing`
       ',

--- a/puppet/modules/joindin/manifests/web.pp
+++ b/puppet/modules/joindin/manifests/web.pp
@@ -110,7 +110,7 @@ class joindin::web ($phpmyadmin = false, $host = 'dev.joind.in', $port = 80) {
     # symlink for icons
     file { "/vagrant/joindin-web2/web/inc":
       ensure => 'link',
-      target => "/vagrant/joind.in/src/inc",
+      target => "/vagrant/joindin-legacy/src/inc",
     }
 
     # set the Apache user to vagrant so that file uploads work

--- a/puppet/modules/joindin/templates/vhost.conf.erb
+++ b/puppet/modules/joindin/templates/vhost.conf.erb
@@ -2,9 +2,9 @@
 
 <VirtualHost *:<%= @port %>>
     ServerAdmin webmaster@<%= @name %>
-    DocumentRoot <%= @docroot %>joind.in/src
-    ServerName <%= @name %>
-    serveralias web1*.ngrok.com
+    DocumentRoot <%= @docroot %>joindin-legacy/src
+    ServerName legacy.<%= @name %>
+    serveralias legacy*.ngrok.com
 <% if @serveraliases != "" -%>
     ServerAlias <%= @serveraliases %>
 <% end -%>
@@ -58,7 +58,7 @@
 
 <virtualhost *:<%= @port %>>
     documentroot <%= @docroot %>joindin-web2/web
-    servername web2.<%= @name %>
+    servername <%= @name %>
     serveralias web2*.ngrok.com
 
     errorlog <%= scope.lookupvar('apache::log_dir') %>/<%= @name %>-error_log

--- a/scripts/cloneRepository.php
+++ b/scripts/cloneRepository.php
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-$repositoryToClone = array('joind.in', 'joindin-api', 'joindin-web2');
+$repositoryToClone = array('joindin-legacy', 'joindin-api', 'joindin-web2');
 
 $path = realpath(__DIR__ . '/../');
 chdir($path);

--- a/scripts/fixConfig.sh
+++ b/scripts/fixConfig.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-sed -i 's/https:\/\/m.joind.in/http:\/\/web2.dev.joind.in/' /vagrant/joindin-api/src/config.php
+sed -i 's/https:\/\/m.joind.in/http:\/\/dev.joind.in/' /vagrant/joindin-api/src/config.php
 sed -i 's/https:\/\/api.joind.in/http:\/\/api.dev.joind.in/' /vagrant/joindin-web2/config/config.php
-sed -i 's/https:\/\/joind.in\//http:\/\/dev.joind.in\//' /vagrant/joind.in/src/system/application/config/config.php
-sed -i 's/https:\/\/api.joind.in\//http:\/\/api.dev.joind.in\//' /vagrant/joind.in/src/system/application/config/config.php
-sed -i "s/^\$config\['token_dir'].*/\$config\['token_dir'\] = '\/tmp\/ctokens';/" /vagrant/joind.in/src/system/application/config/config.php
+sed -i 's/https:\/\/joind.in\//http:\/\/legacy.joind.in\//' /vagrant/joindin-legacy/src/system/application/config/config.php
+sed -i 's/https:\/\/api.joind.in\//http:\/\/api.dev.joind.in\//' /vagrant/joindin-legacy/src/system/application/config/config.php
+sed -i "s/^\$config\['token_dir'].*/\$config\['token_dir'\] = '\/tmp\/ctokens';/" /vagrant/joindin-legacy/src/system/application/config/config.php
 

--- a/scripts/updateRepositories.php
+++ b/scripts/updateRepositories.php
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-$repositoryToUpdate = array('joind.in', 'joindin-api', 'joindin-web2');
+$repositoryToUpdate = array('joindin-web2', 'joindin-api', 'joindin-legacy');
 
 $path = realpath(__DIR__ . '/../');
 chdir($path);


### PR DESCRIPTION
The legacy site's GitHub repository has been renamed from `joind.in` to `joindin-legacy`. This PR updates the provisioning scripts to handle this and also changes the URLs of the two front-facing websites:

* web2 => http//:dev.joind.in
* legacy => http://legacy.dev.joind.in