### PR TITLE
Seed SQL for API write tests

### DIFF
--- a/puppet/modules/joindin/manifests/app.pp
+++ b/puppet/modules/joindin/manifests/app.pp
@@ -34,6 +34,16 @@ class joindin::app (
 	]
     }
 
+    # Add SQL for API write tests
+    exec { 'api-tests-db':
+        creates => '/home/vagrant/.api-write-tests-sql-seeded',
+        command => "mysql -u $dbuser -p$dbpass $dbname < /vagrant/joindin-api/db/init_api_tests.sql && touch /home/vagrant/.api-write-tests-sql-seeded",
+        require => [
+           Exec['patch-db'],
+           Exec['seed-data'],
+        ],
+    }
+
     # Seed database
     exec { 'seed-db':
         creates => '/home/vagrant/.seeded',


### PR DESCRIPTION
To run the API's write tests, we need the SQL defined in `init_api_tests.sql` to be executed.

Note: The API PR https://github.com/joindin/joindin-api/pull/333 needs to be merged before this PR.