### PR TITLE
Use composer for dev install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ by its terms.
    - VirtualBox and the VirtualBox Extension Pack (https://www.virtualbox.org/) (version 4.0 or later)
    - Ruby (http://www.ruby-lang.org/)
    - Vagrant (http://vagrantup.com/) version 1.5+
+   - Composer (https://getcomposer.org/)
 
 1. Make your own github fork of the following joind.in repositories:
 	- [joindin-legacy](https://github.com/joindin/joindin-legacy)

--- a/scripts/cloneRepository.php
+++ b/scripts/cloneRepository.php
@@ -17,6 +17,7 @@ $gitUsername = getGitUsername($remoteString, $useHttps);
 
 array_walk($repositoryToClone, 'cloneRepository', array($gitUsername, $useHttps));
 array_walk($repositoryToClone, 'addUpstreamRemote', $useHttps);
+array_walk($repositoryToClone, 'installViaComposer');
 
 
 function getGitUsername($remoteString, $useHttps) {
@@ -69,4 +70,21 @@ function addUpstreamRemote($repoName, $index, $useHttps) {
 function isHttpsClone($remote) {
 	$pattern = '/\s*Fetch URL:\s+https:\/\//';
 	return preg_match($pattern, $remote);
+}
+
+function installViaComposer($repoName)
+{
+    $windowsAndNixHappyPath = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . $repoName;
+    chdir($windowsAndNixHappyPath);
+
+    if (!file_exists('composer.lock')) {
+        return;
+    }
+
+    echo "Installing dev dependencies for {$repoName}\n";
+
+    $remoteCommand = 'composer install';
+
+    echo $remoteCommand. "\n";
+    system($remoteCommand);
 }

--- a/scripts/updateRepositories.php
+++ b/scripts/updateRepositories.php
@@ -12,10 +12,28 @@ system('git submodule init');
 system('git submodule update');
 
 array_walk($repositoryToUpdate, 'updateRepository');
+array_walk($repositoryToUpdate, 'installViaComposer');
 
 function updateRepository($repoName) {
 	echo "Updating repo {$repoName}\n";
 	chdir($repoName);
 	system("git pull upstream master");
 	chdir('../');
+}
+
+function installViaComposer($repoName)
+{
+    $windowsAndNixHappyPath = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . $repoName;
+    chdir($windowsAndNixHappyPath);
+
+    if (!file_exists('composer.lock')) {
+        return;
+    }
+
+    echo "Installing dev dependencies for {$repoName}\n";
+
+    $remoteCommand = 'composer install';
+
+    echo $remoteCommand. "\n";
+    system($remoteCommand);
 }


### PR DESCRIPTION
Since we are removing the `vendor/` dir and taking advantage of `composer.lock` in the modern repos, we need a way to keep the `vendor/` dir up-to-date with our latest changes. This makes it a little easier to rebuild the `vendor/` dir as needed.