### PR TITLE
We should update apt before installing any packages

### DIFF
--- a/after.sh
+++ b/after.sh
@@ -22,6 +22,7 @@ php ~/joindin-vm/joindin-api/tools/dbgen/generate.php | mysql -u homestead -psec
 ## Install server applications
 
 # Install Wireshark
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y update
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y \
     -o Dpkg::Options::="--force-confdef" \
     -o Dpkg::Options::="--force-confold" \


### PR DESCRIPTION
```
    joindin-vm: E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/universe/w/wireshark/libwireshark11_2.6.6-1~ubuntu18.04.0_amd64.deb  404  Not Found [IP: 91.189.88.152 80]
    joindin-vm: E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/universe/w/wireshark/wireshark-common_2.6.6-1~ubuntu18.04.0_amd64.deb  404  Not Found [IP: 91.189.88.152 80]
    joindin-vm: E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/universe/w/wireshark/tshark_2.6.6-1~ubuntu18.04.0_amd64.deb  404  Not Found [IP: 91.189.88.152 80]
    joindin-vm: E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
vagrant up: 01:44
```